### PR TITLE
HY - Add Moderate Aliases page with approve/reject functionality

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import MealTimesPage from "main/pages/Meal/MealTimesPage";
 
 import ModerateMenuPage from "main/pages/ModerateMenuPage";
 import ModerateReviewsPage from "main/pages/ModerateReviewsPage";
+import ModerateAliasesPage from "main/pages/ModerateAliasesPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -58,6 +59,11 @@ function App() {
               exact
               path="/moderate/reviews"
               element={<ModerateReviewsPage />}
+            />
+            <Route
+              exact
+              path="/moderate/aliases"
+              element={<ModerateAliasesPage />}
             />
           </>
         )}

--- a/frontend/src/main/components/AliasApproval/AliasApprovalTable.jsx
+++ b/frontend/src/main/components/AliasApproval/AliasApprovalTable.jsx
@@ -1,28 +1,34 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
 
-export default function AliasApprovalTable({
-  aliases,
-  approveCallback,
-  rejectCallback,
-}) {
-  const testid = "Aliasapprovaltable";
+export default function AliasApprovalTable({ aliases, onApprove, onReject }) {
+  const testid = "AliasApprovalTable";
 
   const columns = [
     {
       Header: "Proposed Alias",
       accessor: "proposedAlias",
+      Cell: ({ value }) => value || "(No proposed alias)",
     },
+    ButtonColumn(
+      "Approve",
+      "primary",
+      (cell) => onApprove(cell.row.original),
+      testid,
+    ),
+    ButtonColumn(
+      "Reject",
+      "danger",
+      (cell) => onReject(cell.row.original),
+      testid,
+    ),
   ];
 
-  columns.push(ButtonColumn("Approve", "primary", approveCallback, testid));
-  columns.push(ButtonColumn("Reject", "danger", rejectCallback, testid));
+  if (!aliases || aliases.length === 0) {
+    return (
+      <div data-testid={`${testid}-empty`}>No aliases awaiting approval</div>
+    );
+  }
 
-  return (
-    <OurTable
-      data={aliases.filter((user) => user.status === "AWAITING_REVIEW")}
-      columns={columns}
-      testid={testid}
-    />
-  );
+  return <OurTable data={aliases} columns={columns} testid={testid} />;
 }

--- a/frontend/src/main/pages/ModerateAliasesPage.jsx
+++ b/frontend/src/main/pages/ModerateAliasesPage.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import AliasApprovalTable from "main/components/AliasApproval/AliasApprovalTable";
+import { toast } from "react-toastify";
+
+const ModerateAliasesPage = () => {
+  const {
+    data: users,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/admin/usersWithProposedAlias"],
+    // Stryker disable next-line all : don't test internal caching of React Query
+    { method: "GET", url: "/api/admin/usersWithProposedAlias" },
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [],
+  );
+
+  const objectToAxiosPutParams = (params) => ({
+    url: "/api/currentUser/updateAliasModeration",
+    method: "PUT",
+    params: {
+      id: params.id,
+      approved: params.approved,
+    },
+  });
+
+  const onSuccess = () => {
+    toast.success(`Alias moderation updated successfully`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/admin/usersWithProposedAlias"],
+  );
+
+  const handleApprove = async (user) => {
+    mutation.mutate({ id: user.id, approved: true });
+  };
+
+  const handleReject = async (user) => {
+    mutation.mutate({ id: user.id, approved: false });
+  };
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Moderate Aliases</h1>
+        <AliasApprovalTable
+          aliases={users}
+          onApprove={handleApprove}
+          onReject={handleReject}
+        />
+      </div>
+    </BasicLayout>
+  );
+};
+
+export default ModerateAliasesPage;

--- a/frontend/src/main/pages/ModerateMenuPage.jsx
+++ b/frontend/src/main/pages/ModerateMenuPage.jsx
@@ -23,10 +23,10 @@ const ModerateMenuPage = () => {
           <Card.Body>
             <Card.Title>Moderate Aliases</Card.Title>
             <Card.Text>
-              Coming soon: manage user alias requests from this page.
+              Review and approve or reject pending user alias requests.
             </Card.Text>
-            <Button variant="secondary" disabled>
-              Coming Soon
+            <Button as={Link} to="/moderate/aliases" variant="primary">
+              Go to Moderate Aliases
             </Button>
           </Card.Body>
         </Card>

--- a/frontend/src/stories/components/AliasApproval/AliasApprovalTable.stories.jsx
+++ b/frontend/src/stories/components/AliasApproval/AliasApprovalTable.stories.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import AliasApprovalTable from "main/components/AliasApproval/AliasApprovalTable";
 import usersFixtures from "fixtures/usersFixtures";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { action } from "@storybook/addon-actions";
+import { MemoryRouter } from "react-router";
 
 export default {
   title: "components/AliasApproval/AliasApprovalTable",
@@ -12,7 +12,9 @@ export default {
       const queryClient = new QueryClient();
       return (
         <QueryClientProvider client={queryClient}>
-          <Story />
+          <MemoryRouter>
+            <Story />
+          </MemoryRouter>
         </QueryClientProvider>
       );
     },
@@ -24,13 +26,13 @@ const Template = (args) => <AliasApprovalTable {...args} />;
 export const EmptyTable = Template.bind({});
 EmptyTable.args = {
   aliases: [],
-  onApprove: action("onApprove"),
-  onReject: action("onReject"),
+  onApprove: () => {},
+  onReject: () => {},
 };
 
 export const ThreeUsers = Template.bind({});
 ThreeUsers.args = {
   aliases: usersFixtures.threeUsers,
-  onApprove: action("onApprove"),
-  onReject: action("onReject"),
+  onApprove: () => {},
+  onReject: () => {},
 };

--- a/frontend/src/stories/components/AliasApproval/AliasApprovalTable.stories.jsx
+++ b/frontend/src/stories/components/AliasApproval/AliasApprovalTable.stories.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import AliasApprovalTable from "main/components/AliasApproval/AliasApprovalTable";
+import usersFixtures from "fixtures/usersFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { action } from "@storybook/addon-actions";
+
+export default {
+  title: "components/AliasApproval/AliasApprovalTable",
+  component: AliasApprovalTable,
+  decorators: [
+    (Story) => {
+      const queryClient = new QueryClient();
+      return (
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+const Template = (args) => <AliasApprovalTable {...args} />;
+
+export const EmptyTable = Template.bind({});
+EmptyTable.args = {
+  aliases: [],
+  onApprove: action("onApprove"),
+  onReject: action("onReject"),
+};
+
+export const ThreeUsers = Template.bind({});
+ThreeUsers.args = {
+  aliases: usersFixtures.threeUsers,
+  onApprove: action("onApprove"),
+  onReject: action("onReject"),
+};

--- a/frontend/src/stories/pages/ModerateAliasesPage.stories.jsx
+++ b/frontend/src/stories/pages/ModerateAliasesPage.stories.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router";
+import ModerateAliasesPage from "main/pages/ModerateAliasesPage";
+
+export default {
+  title: "pages/ModerateAliasesPage",
+  component: ModerateAliasesPage,
+};
+
+const Template = () => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ModerateAliasesPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/components/AliasApprovalTable/AliasApprovalTable.test.jsx
+++ b/frontend/src/tests/components/AliasApprovalTable/AliasApprovalTable.test.jsx
@@ -1,76 +1,158 @@
-import React from "react";
-import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import AliasApprovalTable from "main/components/AliasApproval/AliasApprovalTable";
-import { QueryClient, QueryClientProvider } from "react-query";
 import usersFixtures from "fixtures/usersFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router";
 import { vi } from "vitest";
+
+const mockedNavigate = vi.fn();
+
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
 
 describe("AliasApprovalTable tests", () => {
   const queryClient = new QueryClient();
 
-  it("renders the header even with no data", () => {
-    render(<AliasApprovalTable aliases={[]} />);
-
-    expect(screen.getByText("Proposed Alias")).toBeInTheDocument();
-
-    expect(
-      screen.getByTestId("Aliasapprovaltable-header-proposedAlias"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("Aliasapprovaltable-header-Approve"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("Aliasapprovaltable-header-Reject"),
-    ).toBeInTheDocument();
-  });
-
-  it("renders a data row for each user", () => {
-    render(<AliasApprovalTable aliases={usersFixtures.threeUsers} />);
-    expect(screen.getByText("Ali1")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("Aliasapprovaltable-cell-row-1-col-proposedAlias"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("buttons appear and work properly", async () => {
-    const approveCallback = vi.fn();
-    const rejectCallback = vi.fn();
-
+  test("renders empty table correctly", () => {
     render(
       <QueryClientProvider client={queryClient}>
-        <AliasApprovalTable
-          aliases={usersFixtures.threeUsers}
-          approveCallback={approveCallback}
-          rejectCallback={rejectCallback}
-        />
-        ,
+        <MemoryRouter>
+          <AliasApprovalTable
+            aliases={[]}
+            onApprove={vi.fn()}
+            onReject={vi.fn()}
+          />
+        </MemoryRouter>
       </QueryClientProvider>,
     );
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId(`Aliasapprovaltable-cell-row-0-col-proposedAlias`),
-      ).toHaveTextContent("Ali1");
+    expect(screen.getByTestId("AliasApprovalTable-empty")).toBeInTheDocument();
+    expect(
+      screen.getByText("No aliases awaiting approval"),
+    ).toBeInTheDocument();
+  });
+
+  test("renders table with users correctly", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AliasApprovalTable
+            aliases={usersFixtures.threeUsers}
+            onApprove={vi.fn()}
+            onReject={vi.fn()}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = ["Proposed Alias"];
+    const expectedFields = ["proposedAlias"];
+    const testId = "AliasApprovalTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    //approve button
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-proposedAlias`),
+    ).toHaveTextContent("Ali1");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-proposedAlias`),
+    ).toHaveTextContent("(No proposed alias)");
+
     const approveButton = screen.getByTestId(
-      `Aliasapprovaltable-cell-row-0-col-Approve-button`,
+      `${testId}-cell-row-0-col-Approve-button`,
     );
     expect(approveButton).toBeInTheDocument();
     expect(approveButton).toHaveClass("btn-primary");
 
-    fireEvent.click(approveButton);
-    expect(approveCallback).toHaveBeenCalledTimes(1);
-
-    //reject button
     const rejectButton = screen.getByTestId(
-      `Aliasapprovaltable-cell-row-0-col-Reject-button`,
+      `${testId}-cell-row-0-col-Reject-button`,
     );
     expect(rejectButton).toBeInTheDocument();
     expect(rejectButton).toHaveClass("btn-danger");
+  });
 
+  test("Approve button calls onApprove callback", () => {
+    const onApproveMock = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AliasApprovalTable
+            aliases={usersFixtures.threeUsers}
+            onApprove={onApproveMock}
+            onReject={vi.fn()}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const approveButton = screen.getByTestId(
+      "AliasApprovalTable-cell-row-0-col-Approve-button",
+    );
+    fireEvent.click(approveButton);
+
+    expect(onApproveMock).toHaveBeenCalledWith(usersFixtures.threeUsers[0]);
+  });
+
+  test("Reject button calls onReject callback", () => {
+    const onRejectMock = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AliasApprovalTable
+            aliases={usersFixtures.threeUsers}
+            onApprove={vi.fn()}
+            onReject={onRejectMock}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const rejectButton = screen.getByTestId(
+      "AliasApprovalTable-cell-row-0-col-Reject-button",
+    );
     fireEvent.click(rejectButton);
-    expect(rejectCallback).toHaveBeenCalledTimes(1);
+
+    expect(onRejectMock).toHaveBeenCalledWith(usersFixtures.threeUsers[0]);
+  });
+
+  test("renders (No proposed alias) when proposedAlias is null", () => {
+    const usersWithNullAlias = [
+      {
+        ...usersFixtures.threeUsers[0],
+        proposedAlias: null,
+      },
+    ];
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AliasApprovalTable
+            aliases={usersWithNullAlias}
+            onApprove={vi.fn()}
+            onReject={vi.fn()}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByTestId("AliasApprovalTable-cell-row-0-col-proposedAlias"),
+    ).toHaveTextContent("(No proposed alias)");
   });
 });

--- a/frontend/src/tests/pages/ModerateAliasesPage.test.jsx
+++ b/frontend/src/tests/pages/ModerateAliasesPage.test.jsx
@@ -1,0 +1,249 @@
+import { render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router";
+import ModerateAliasesPage from "main/pages/ModerateAliasesPage";
+import { vi } from "vitest";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import usersFixtures from "fixtures/usersFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async () => {
+  const originalModule = await vi.importActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: {
+      success: (x) => mockToast(x),
+      error: (x) => mockToast(x),
+    },
+  };
+});
+
+describe("ModerateAliasesPage Tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "AliasApprovalTable";
+
+  const setupModerator = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.moderatorUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const setupAdmin = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  test("renders aliases with approve/reject buttons for moderator", async () => {
+    setupModerator();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/admin/usersWithProposedAlias")
+      .reply(200, usersFixtures.threeUsers);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModerateAliasesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-proposedAlias`),
+      ).toHaveTextContent("Ali1");
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Approve-button`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Reject-button`),
+    ).toBeInTheDocument();
+  });
+
+  test("renders aliases with approve/reject buttons for admin", async () => {
+    setupAdmin();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/admin/usersWithProposedAlias")
+      .reply(200, usersFixtures.threeUsers);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModerateAliasesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-proposedAlias`),
+      ).toHaveTextContent("Ali1");
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Approve-button`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Reject-button`),
+    ).toBeInTheDocument();
+  });
+
+  test("handles error when backend is unavailable for moderator", async () => {
+    setupModerator();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/admin/usersWithProposedAlias").timeout();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModerateAliasesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // When backend times out, should show empty state
+    await waitFor(() => {
+      expect(screen.getByTestId(`${testId}-empty`)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-proposedAlias`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty message when no aliases pending", async () => {
+    setupModerator();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/admin/usersWithProposedAlias").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModerateAliasesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`${testId}-empty`)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("No aliases awaiting approval"),
+    ).toBeInTheDocument();
+  });
+
+  test("approve button calls mutation and shows success toast", async () => {
+    setupAdmin();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/admin/usersWithProposedAlias")
+      .reply(200, usersFixtures.threeUsers);
+    axiosMock
+      .onPut("/api/currentUser/updateAliasModeration")
+      .reply(200, usersFixtures.threeUsers[0]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModerateAliasesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-Approve-button`),
+      ).toBeInTheDocument();
+    });
+
+    const approveButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Approve-button`,
+    );
+    approveButton.click();
+
+    await waitFor(() => {
+      expect(axiosMock.history.put.length).toBe(1);
+    });
+
+    expect(axiosMock.history.put[0].params).toEqual({
+      id: 1,
+      approved: true,
+    });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        "Alias moderation updated successfully",
+      );
+    });
+  });
+
+  test("reject button calls mutation and shows success toast", async () => {
+    setupAdmin();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/admin/usersWithProposedAlias")
+      .reply(200, usersFixtures.threeUsers);
+    axiosMock
+      .onPut("/api/currentUser/updateAliasModeration")
+      .reply(200, usersFixtures.threeUsers[0]);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModerateAliasesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-Reject-button`),
+      ).toBeInTheDocument();
+    });
+
+    const rejectButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Reject-button`,
+    );
+    rejectButton.click();
+
+    await waitFor(() => {
+      expect(axiosMock.history.put.length).toBe(1);
+    });
+
+    expect(axiosMock.history.put[0].params).toEqual({
+      id: 1,
+      approved: false,
+    });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        "Alias moderation updated successfully",
+      );
+    });
+  });
+});

--- a/frontend/src/tests/pages/ModerateMenuPage.test.jsx
+++ b/frontend/src/tests/pages/ModerateMenuPage.test.jsx
@@ -42,9 +42,9 @@ describe("ModerateMenuPage tests", () => {
     });
     expect(reviewsLink).toHaveAttribute("href", "/moderate/reviews");
 
-    const comingSoonButton = screen.getByRole("button", {
-      name: "Coming Soon",
+    const aliasesLink = screen.getByRole("button", {
+      name: "Go to Moderate Aliases",
     });
-    expect(comingSoonButton).toBeDisabled();
+    expect(aliasesLink).toHaveAttribute("href", "/moderate/aliases");
   });
 });

--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,7 @@
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
           <commitIdGenerationMode>full</commitIdGenerationMode>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,6 @@
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
           <commitIdGenerationMode>full</commitIdGenerationMode>
-          <failOnNoGitDirectory>false</failOnNoGitDirectory>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
closes #10 

Implements the Moderate Aliases feature, allowing admins to review and approve/reject pending user alias requests.

## Dokku Deployment
https://dining-dev-hechenjin.dokku-05.cs.ucsb.edu

## StoryBook link
https://69151080fa9616ab79ba4642-innecucwry.chromatic.com/?path=/docs/components-aliasapprovaltable-aliasapprovaltable--docs

## How to Test
1. Login
2. Go to the swagger page and add a alias in api/currentUser/updateAlias<img width="724" height="816" alt="Screenshot 2025-11-23 at 7 58 32 PM" src="https://github.com/user-attachments/assets/474183fe-40ce-4444-9368-c8e6eeae4d22" />
3. Go back to the homepage
4. Open the menu and select 'Moderate'
5. Select Go to 'Moderate Aliases' to check the alia you just added<img width="995" height="202" alt="Screenshot 2025-11-23 at 8 07 54 PM" src="https://github.com/user-attachments/assets/fb0684ea-0de0-4235-942b-6fbdb6de95fe" />


